### PR TITLE
Removed short-circuiting return statement.

### DIFF
--- a/Classes/OrgBeuckmanTibeaconsModule.m
+++ b/Classes/OrgBeuckmanTibeaconsModule.m
@@ -316,7 +316,6 @@
         NSLog(@"[INFO] Didn't turn off ranging: Ranging already off.");
         return;
     }
-    return;
     
     NSArray *regions = [self.locationManager.rangedRegions allObjects];
     for (CLBeaconRegion *region in regions) {


### PR DESCRIPTION
The stopRangingForAllBeacons function had a return statement after a conditional
that made the remaining portion of the function unreachable.